### PR TITLE
Extend Get() to return counters.

### DIFF
--- a/job.go
+++ b/job.go
@@ -2,7 +2,9 @@ package disque
 
 // Job represents job/message returned from a Disque server.
 type Job struct {
-	ID    string
-	Data  string
-	Queue string
+	ID                   string
+	Data                 string
+	Queue                string
+	Nacks                int64
+	AdditionalDeliveries int64
 }


### PR DESCRIPTION
I'm not wild about the API, obviously the Job and Counters struct could be merged. Also at some point NOHANG and COUNT should be exposed, and at that point having a method per variation would be unwieldy.

Maybe Get needs to take a options struct? :-(

Any feedback would be greatly appreciated.
