### PR TITLE
Expand Job details and add fetch function

### DIFF
--- a/disque.go
+++ b/disque.go
@@ -239,19 +239,21 @@ func (pool *Pool) Fetch(ID string) (*Job, error) {
 
 	job := Job{}
 
-	if bytes, ok := arr[1].([]byte); ok {
+	var bytes []byte
+
+	if bytes, ok = arr[1].([]byte); ok {
 		job.ID = string(bytes)
 	} else {
 		return nil, errors.New("unexpected reply: id")
 	}
 
-	if bytes, ok := arr[3].([]byte); ok {
+	if bytes, ok = arr[3].([]byte); ok {
 		job.Queue = string(bytes)
 	} else {
 		return nil, errors.New("unexpected reply: queue")
 	}
 
-	if bytes, ok := arr[5].([]byte); ok {
+	if bytes, ok = arr[5].([]byte); ok {
 		job.State = string(bytes)
 	} else {
 		return nil, errors.New("unexpected reply: state")

--- a/disque_test.go
+++ b/disque_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"disque"
+	"github.com/goware/disque"
 )
 
 func TestPing(t *testing.T) {

--- a/disque_test.go
+++ b/disque_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/goware/disque"
+	"disque"
 )
 
 func TestPing(t *testing.T) {
@@ -19,6 +19,37 @@ func TestPing(t *testing.T) {
 	if jobs.Ping() != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestFetch(t *testing.T) {
+	// Connect to Disque.
+	jobs, err := disque.New("127.0.0.1:7711")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer jobs.Close()
+
+	// Add.
+	job, err := jobs.Add("data0x5f3759df", "test:fetch")
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Fetch.
+	_job, err := jobs.Fetch(job.ID)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Job should have been fetched and content of two jobs should be equal
+	if _job == nil {
+		t.Fatal("expected job to be fetched")
+	}
+	if job.Data != _job.Data {
+		t.Error("expected data of the jobs to be equal")
+	}
+
+	jobs.Ack(_job)
 }
 
 func TestDelay(t *testing.T) {
@@ -281,7 +312,7 @@ func TestQueueLength(t *testing.T) {
 		t.Error(err)
 	}
 	if length != 0 {
-		t.Error("unexpected length %v", length)
+		t.Fatalf("unexpected length %v", length)
 	}
 
 	// Enqueue hundred jobs.

--- a/job.go
+++ b/job.go
@@ -1,10 +1,18 @@
 package disque
 
+import "time"
+
 // Job represents job/message returned from a Disque server.
 type Job struct {
 	ID                   string
 	Data                 string
 	Queue                string
+	State                string
+	TTL                  time.Duration
+	Delay                time.Duration
+	Retry                time.Duration
+	CreatedAt            time.Time
+	Replication          int64
 	Nacks                int64
 	AdditionalDeliveries int64
 }


### PR DESCRIPTION
To account for the `show <job-id>` command, I added the `Fetch` function to allow for getting the job from the queues without the intent of processing, which is useful for management purposes.

In addition, I also expanded the Job struct to carry useful information such as delay, ttl, creation time, and etc.
